### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/pitrho/react-gridstack.git#readme",
   "peerDependencies": {
-    "react": "~0.14.7",
-    "react-dom": "~0.14.5"
+    "react": ">= 0.14.7",
+    "react-dom": ">= 0.14.5"
   },
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
peer dependencies error when trying to use react-gridstack with bigger version of react 0.14.7
